### PR TITLE
remove adaptiveness from SwitchListTiles

### DIFF
--- a/lib/presentation/screens/settings/theme/widgets/auto_color_scheme_tile.dart
+++ b/lib/presentation/screens/settings/theme/widgets/auto_color_scheme_tile.dart
@@ -10,7 +10,7 @@ class AutoColorSchemeTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SettingsCubit, SettingsState>(
       builder: (context, state) {
-        return SwitchListTile.adaptive(
+        return SwitchListTile(
           value: state.themeType == ThemeType.adaptive,
           title: Text(LocaleKeys.dynamic_colors.tr()),
           subtitle: Text(LocaleKeys.dynamic_colors_desc.tr()),

--- a/lib/presentation/screens/settings/theme/widgets/retro_color_scheme_tile.dart
+++ b/lib/presentation/screens/settings/theme/widgets/retro_color_scheme_tile.dart
@@ -10,7 +10,7 @@ class RetroColorSchemeTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SettingsCubit, SettingsState>(
       builder: (context, state) {
-        return SwitchListTile.adaptive(
+        return SwitchListTile(
           value: state.themeType == ThemeType.retro,
           title: Text(LocaleKeys.retro_colors.tr()),
           subtitle: Text(LocaleKeys.retro_colors_desc.tr()),

--- a/lib/presentation/screens/settings/widgets/dark_theme_mode_tile.dart
+++ b/lib/presentation/screens/settings/widgets/dark_theme_mode_tile.dart
@@ -28,7 +28,7 @@ class DarkThemeModeTile extends StatelessWidget {
               ThemeMode.light => (enabled: true, isDark: false),
             };
 
-            return SwitchListTile.adaptive(
+            return SwitchListTile(
               title: Text(LocaleKeys.theme_dark.tr()),
               subtitle: Text(LocaleKeys.theme_dark_desc.tr()),
               onChanged: switchState.enabled

--- a/lib/presentation/screens/settings/widgets/show_fab_switch_tile.dart
+++ b/lib/presentation/screens/settings/widgets/show_fab_switch_tile.dart
@@ -9,7 +9,7 @@ class ShowFabSwitchTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<SettingsCubit, SettingsState>(
       builder: (context, state) {
-        return SwitchListTile.adaptive(
+        return SwitchListTile(
           value: state.isFabHidden,
           title: Text(LocaleKeys.hide_fab.tr()),
           subtitle: Text(LocaleKeys.hide_fab_desc.tr()),


### PR DESCRIPTION
Full focus narazie na design zgodny z Material 3, toteż pousuwałem .adaptive() dla SwitchListTiles